### PR TITLE
feat(config): デフォルト設定をClaude 3.5 Sonnetに変更

### DIFF
--- a/internal/templates/config.json
+++ b/internal/templates/config.json
@@ -1,6 +1,6 @@
 {
-  "llm_provider": "openai",
-  "model": "gpt-4",
+  "llm_provider": "claude",
+  "model": "claude-3-5-sonnet-20241022",
   "temperature": 0.7,
   "max_tokens": 2000
 }


### PR DESCRIPTION
## 変更概要

デフォルトのLLMプロバイダーをOpenAIからClaudeに変更し、モデルをClaude 3.5 Sonnet (20241022)に更新しました。

## 実装詳細

- `internal/templates/config.json`のデフォルト設定を更新
- `llm_provider`を"openai"から"claude"に変更
- `model`を"gpt-4"から"claude-3-5-sonnet-20241022"に変更

## 特に見て欲しい観点

特になし

## リファレンス

特になし